### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In your `build.gradle`:
 
 ```gradle
  dependencies {
-   compile 'com.github.frank-zhu:pullzoomview:1.0.0'
+   implementation 'com.github.frank-zhu:pullzoomview:1.0.0'
  }
 ```
 or Maven:


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.